### PR TITLE
db.indra.bio page updates

### DIFF
--- a/src/components/AgentSelect/AgentSelect.vue
+++ b/src/components/AgentSelect/AgentSelect.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="agent-select">
     <span class="label">role:</span>
-    <select class="form-control" v-model="role_str">
+    <select class="form-control role-dropdown" v-model="role_str">
       <option v-for="role in role_options" :key="role" :value="role">
         {{ role }}
       </option>
@@ -45,8 +45,8 @@
 
     <span v-else-if="options.length === 1">
       <span class="label">GILDA grounding:</span>
-      <span class="form-control" v-html="printOption(options[0])"></span>
-      <button class="btn btn-primary" @click="resetOptions">Cancel</button>
+      <span class="form-control gilda-dropdown" v-html="printOption(options[0])"></span>
+      <button class="agent-select-button btn btn-primary" @click="resetOptions">Cancel</button>
     </span>
 
     <span v-else>
@@ -70,7 +70,7 @@
 <script>
 export default {
   name: 'AgentSelect',
-  props: ['value'],
+  props: ['value','exampleTick'],
   data () {
     return {
       role_str: 'any',
@@ -79,7 +79,7 @@ export default {
       options: null,
       selected_option_idx: -1,
       search_error: null,
-      role_options: ['subject', 'object', 'any']
+      role_options: ['subject', 'object', 'any'],
     }
   },
   methods: {
@@ -164,37 +164,46 @@ export default {
     }
   },
   watch: {
+    exampleTick () {
+    const v = this.value || {};
+    this.agent_str = typeof v.agent_id === 'string' ? v.agent_id : '';
+    this.role_str  = typeof v.role === 'string' ? v.role : 'any';
+    // make sure it does not affect grounding button
+    this.options = null;
+    this.selected_option_idx = -1;
+    this.search_error = null;
+  },
     constraint (c) {
-      this.$emit('input', c)
+    this.$emit('input', c)
     }
   }
 }
 </script>
-
 <style scoped>
-.agent-select {
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-  margin: 0.2em;
-}
+  .agent-select {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0.2em;
+  }
 
-.agent-select select.form-control,
-.agent-select input.form-control {
-  display: inline-block;
-  width: 200px;
-}
+  .agent-select .role-dropdown {
+    width: 80px;
+    display: inline-flex;
+  }
 
-.agent-select select.form-control {
-  width: 80px;            /* role dropdown */
-}
+  .agent-select input.form-control {
+    width: 250px;
+    display: inline-flex;
+  }
 
-.agent-select .gilda-dropdown {
-  min-width: 350px;
-}
-.agent-select .btn { margin-left: 6px; }
+  .agent-select .gilda-dropdown {
+    min-width: 250px;
+    width: auto;
+    display: inline-flex;
+  }
 
-/* optional: keep the hint + "OR" on same line */
-.agent-select .hint { margin-left: 6px; white-space: nowrap; color: #666; }
-.agent-select .sep  { margin: 0 8px;   color: #888; }
+  .agent-select .btn {
+    margin-left: 6px;
+  }
 </style>

--- a/src/components/AgentSelect/AgentSelect.vue
+++ b/src/components/AgentSelect/AgentSelect.vue
@@ -30,7 +30,7 @@
 
       <span class="sep">OR</span>
       <button class="agent-select-button btn btn-primary" @click="lookupOptions">
-        Find Identifier with GILDA
+        Find Identifier with Gilda
       </button>
       <span v-show="searching">Searching...</span>
       <span v-show="options_empty">No groundings found...</span>
@@ -51,7 +51,7 @@
 
     <span v-else>
       <span class="label">GILDA grounding:</span>
-      <select class="form-control" v-model="selected_option_idx">
+      <select class="form-control gilda-dropdown" v-model="selected_option_idx">
         <option :value="-1" selected disabled hidden>Select grounding option...</option>
         <option
           v-for="(option, option_idx) in options"
@@ -182,17 +182,16 @@ export default {
 .agent-select select.form-control,
 .agent-select input.form-control {
   display: inline-block;
+  width: 200px;
 }
 
 .agent-select select.form-control {
   width: 80px;            /* role dropdown */
 }
 
-.agent-select input.form-control {
-  width: 200px;            /* agent input */
-  max-width: 60vw;
+.agent-select .gilda-dropdown {
+  min-width: 350px;
 }
-
 .agent-select .btn { margin-left: 6px; }
 
 /* optional: keep the hint + "OR" on same line */

--- a/src/components/AgentSelect/AgentSelect.vue
+++ b/src/components/AgentSelect/AgentSelect.vue
@@ -32,7 +32,7 @@
         OR
         <button class="agent-select-button btn btn-primary"
                 @click='lookupOptions'>
-            Ground with GILDA
+            Find Identifier with GILDA
         </button>
         <span v-show='searching'>Searching...</span>
         <span v-show='options_empty'>No groundings found...</span>

--- a/src/components/AgentSelect/AgentSelect.vue
+++ b/src/components/AgentSelect/AgentSelect.vue
@@ -1,189 +1,201 @@
 <template>
-  <span class='agent-select'>
-      <span class="label">role:</span>
-      <select class="form-control"
-              v-model='role_str'>
-        <option v-for='role in role_options'
-                :key='role'
-                :value='role'>
-          {{ role }}
-        </option>
-      </select>
-      <span v-if="!options || options_empty">
-        <span class="label">text:</span>
-        <input class="form-control"
-               type="text"
-               v-model="agent_str"
-               placeholder="Enter agent here">
-        <span class="label">namespace:</span>
-        <select v-model="namespace"
-                class="form-control"
-                title="namespace">
-          <option v-for="option in namespace_options"
-                  :key="option"
-                  :value="option">
-            {{ option }}
-          </option>
-        </select>
-        <input v-if="namespace === 'other'"
-               class="form-control"
-               v-model="custom_namespace"
-               placeholder="Enter namespace...">
-        OR
-        <button class="agent-select-button btn btn-primary"
-                @click='lookupOptions'>
-            Find Identifier with GILDA
-        </button>
-        <span v-show='searching'>Searching...</span>
-        <span v-show='options_empty'>No groundings found...</span>
-        <i style="color: red; cursor: default"
-           v-show="search_error"
-           :title="search_error">
-          Search failed!
-        </i>
-      </span>
-      <span v-else-if="options.length === 1">
-        <span class="label">GILDA grounding:</span>
-        <span class='form-control' v-html="printOption(options[0])"></span>
-        <button class="btn btn-primary"
-                @click='resetOptions'>
-            Cancel
-        </button>
-      </span>
-      <span v-else>
-        <span class="label">GILDA grounding:</span>
-        <select class="form-control" v-model='selected_option_idx'>
-          <option :value='-1' selected disabled hidden>Select grounding option...</option>
-          <option v-for='(option, option_idx) in options'
-                  :key='option_idx'
-                  :value='option_idx'
-                  v-html="printOption(option)">
-          </option>
-        </select>
-        <button class="agent-select-button btn btn-primary"
-                @click='resetOptions'>
-            Cancel
-        </button>
-      </span>
+  <span class="agent-select">
+    <span class="label">role:</span>
+    <select class="form-control" v-model="role_str">
+      <option v-for="role in role_options" :key="role" :value="role">
+        {{ role }}
+      </option>
+    </select>
+
+    <span v-if="!options || options_empty">
+      <input
+        class="form-control"
+        type="text"
+        v-model="agent_str"
+        placeholder="Enter agent here"
+      />
+
+      <!-- live hint, replaces the old namespace selector -->
+      <small class="hint" v-if="agent_str">
+        <template v-if="detectedNamespace === 'HGNC'">
+          Searching by <b>HGNC</b> identifier (e.g. 'hgnc:3236')
+        </template>
+        <template v-else-if="detectedNamespace === 'FPLX'">
+          Searching by <b>FPLX</b> identifier (e.g. 'fplx:MAPK')
+        </template>
+        <template v-else>
+          Searching by <b>text name</b> (e.g. 'EGFR')
+        </template>
+      </small>
+
+      <span class="sep">OR</span>
+      <button class="agent-select-button btn btn-primary" @click="lookupOptions">
+        Find Identifier with GILDA
+      </button>
+      <span v-show="searching">Searching...</span>
+      <span v-show="options_empty">No groundings found...</span>
+      <i
+        style="color: red; cursor: default"
+        v-show="search_error"
+        :title="search_error"
+      >
+        Search failed!
+      </i>
     </span>
+
+    <span v-else-if="options.length === 1">
+      <span class="label">GILDA grounding:</span>
+      <span class="form-control" v-html="printOption(options[0])"></span>
+      <button class="btn btn-primary" @click="resetOptions">Cancel</button>
+    </span>
+
+    <span v-else>
+      <span class="label">GILDA grounding:</span>
+      <select class="form-control" v-model="selected_option_idx">
+        <option :value="-1" selected disabled hidden>Select grounding option...</option>
+        <option
+          v-for="(option, option_idx) in options"
+          :key="option_idx"
+          :value="option_idx"
+          v-html="printOption(option)"
+        ></option>
+      </select>
+      <button class="agent-select-button btn btn-primary" @click="resetOptions">
+        Cancel
+      </button>
+    </span>
+  </span>
 </template>
 
 <script>
-  export default {
-    name: "AgentSelect",
-    props: ['value'],
-    data: function() {
-      return {
-        role_str: 'any',
-        agent_str: '',
-        searching: false,
-        options: null,
-        selected_option_idx: -1,
-        namespace: "auto",
-        role_options: [
-          'subject',
-          'object',
-          'any',
-        ],
-        namespace_options: [
-          "auto",
-          "text",
-          "name",
-          "fplx",
-          "hgnc",
-          "other"
-        ],
-        custom_namespace: null,
-        search_error: null,
+export default {
+  name: 'AgentSelect',
+  props: ['value'],
+  data () {
+    return {
+      role_str: 'any',
+      agent_str: '',
+      searching: false,
+      options: null,
+      selected_option_idx: -1,
+      search_error: null,
+      role_options: ['subject', 'object', 'any']
+    }
+  },
+  methods: {
+    async lookupOptions () {
+      this.searching = true
+      if (!this.agent_str) {
+        alert('Please enter an agent string...')
+        this.searching = false
+        return
       }
-    },
-    methods: {
-      lookupOptions: async function() {
-        this.searching = true;
-        if (!this.agent_str) {
-          alert("Please enter an agent string...");
-          this.searching=false;
-          return;
-        }
-        const resp = await fetch(
-          `${this.$ground_url}?agent=${this.agent_str}`,
-          {method: 'GET'}
-          );
-        if (resp.status === 200) {
-          this.options = await resp.json();
-          if (this.options.length === 1)
-            this.selected_option_idx = 0;
-          this.search_error = null;
-        } else {
-          this.search_error = `(${resp.status}) ${resp.statusText}`
-        }
-        this.searching = false;
-      },
-      resetOptions: function() {
-        this.options = null;
-        this.selected_option_idx = -1;
-      },
-      printOption: function(option) {
-        let term = option.term;
-        return (`<b>${term.entry_name}</b> (score: ${option.score.toFixed(2)}, `
-                + `${term.id} from ${term.db})`);
+      const resp = await fetch(`${this.$ground_url}?agent=${encodeURIComponent(this.agent_str)}`, { method: 'GET' })
+      if (resp.status === 200) {
+        this.options = await resp.json()
+        if (this.options.length === 1) this.selected_option_idx = 0
+        this.search_error = null
+      } else {
+        this.search_error = `(${resp.status}) ${resp.statusText}`
       }
+      this.searching = false
     },
-    computed: {
-      options_empty: function() {
-        if (!this.options)
-          return false;
-        return this.options.length === 0;
-      },
-      constraint: function() {
-        let ret = null;
+    resetOptions () {
+      this.options = null
+      this.selected_option_idx = -1
+    },
+    printOption (option) {
+      const term = option.term
+      return `<b>${term.entry_name}</b> (score: ${option.score.toFixed(2)}, ${term.id} from ${term.db})`
+    }
+  },
+  computed: {
+    options_empty () {
+      if (!this.options) return false
+      return this.options.length === 0
+    },
+    // Detect a prefixed identifier like "hgnc:1234" or "fplx:MAPK"
+    parsedPrefix () {
+      const text = (this.agent_str || '').trim()
+      if (/^hgnc:?/i.test(text)) {
+        const id = text.replace(/^hgnc:?/i, '').trim()
+        return { ns: 'HGNC', id: id || null }
+      }
+      if (/^fplx:?/i.test(text)) {
+        const id = text.replace(/^fplx:?/i, '').trim()
+        return { ns: 'FPLX', id: id || null }
+      }
+      return null
+    },
+    detectedNamespace () {
+      return this.parsedPrefix ? this.parsedPrefix.ns : null
+    },
+    agent_id_from_input () {
+      // if prefixed, return the id part, else the raw text
+      if (this.parsedPrefix) return this.parsedPrefix.id
+      return (this.agent_str || '').trim()
+    },
+    namespace_from_input () {
+      // if prefixed, use that; else mimic the old default behavior ("AUTO")
+      if (this.parsedPrefix) return this.parsedPrefix.ns
+      return 'AUTO'
+    },
+    constraint () {
+      let ret = null
 
-        // Handle the agent part of the query.
-        if (this.agent_str)
-          if (!this.options || this.options_empty) {
-            if (this.namespace !== 'other')
-              ret = {
-                agent_id: this.agent_id,
-                namespace: this.namespace.toUpperCase(),
-              };
-            else if (this.custom_namespace)
-              ret = {
-                agent_id: this.agent_id,
-                namespace: this.custom_namespace.toUpperCase(),
-              };
-          } else {
-            if (this.selected_option_idx >= 0)
-              ret = {
-                agent_id: this.options[this.selected_option_idx].term.id,
-                namespace: this.options[this.selected_option_idx].term.db,
-              };
-          }
-        // Handle the role part.
-        if (ret !== null && this.role_str !== 'any')
-          ret.role = this.role_str;
-        return ret;
-      },
-      agent_id: function() {
-        return this.agent_str.trim();
+      // Case 1: user selected a GILDA grounding explicitly
+      if (this.options && !this.options_empty && this.selected_option_idx >= 0) {
+        const chosen = this.options[this.selected_option_idx]
+        ret = {
+          agent_id: chosen.term.id,
+          namespace: chosen.term.db
+        }
+      } else if (this.agent_id_from_input) {
+        // Case 2: user typed something (possibly with a prefix); no GILDA selection
+        ret = {
+          agent_id: this.agent_id_from_input,
+          namespace: this.namespace_from_input
+        }
       }
-    },
-    watch: {
-      constraint: function(constraint) {
-        this.$emit('input', constraint);
-      }
+
+      // Add role if set
+      if (ret && this.role_str !== 'any') ret.role = this.role_str
+      return ret
+    }
+  },
+  watch: {
+    constraint (c) {
+      this.$emit('input', c)
     }
   }
+}
 </script>
 
 <style scoped>
-  .agent-select {
-    margin: 0.2em;
-  }
-  select, input, button {
-    margin: 0.2em;
-  }
-  .label {
-    margin-left: 0.5em;
-    margin-right: 0.2em;
-  }
+.agent-select {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0.2em;
+}
+
+.agent-select select.form-control,
+.agent-select input.form-control {
+  display: inline-block;
+}
+
+.agent-select select.form-control {
+  width: 80px;            /* role dropdown */
+}
+
+.agent-select input.form-control {
+  width: 200px;            /* agent input */
+  max-width: 60vw;
+}
+
+.agent-select .btn { margin-left: 6px; }
+
+/* optional: keep the hint + "OR" on same line */
+.agent-select .hint { margin-left: 6px; white-space: nowrap; color: #666; }
+.agent-select .sep  { margin: 0 8px;   color: #888; }
 </style>

--- a/src/components/MeshSelect/MeshSelect.vue
+++ b/src/components/MeshSelect/MeshSelect.vue
@@ -9,7 +9,7 @@
         OR
         <button class="agent-select-button btn btn-primary"
                 @click='lookupOptions'>
-            Ground with GILDA
+            Find Identifier with GILDA
         </button>
         <span v-show='searching'>Searching...</span>
         <span v-show='options_empty'>No mesh IDs found...</span>

--- a/src/components/MeshSelect/MeshSelect.vue
+++ b/src/components/MeshSelect/MeshSelect.vue
@@ -1,7 +1,6 @@
 <template>
   <span class="mesh-select">
       <span v-if="!options || options_empty">
-        <span class="label">text:</span>
         <input class="form-control"
                type="text"
                v-model="mesh_str"

--- a/src/components/MeshSelect/MeshSelect.vue
+++ b/src/components/MeshSelect/MeshSelect.vue
@@ -8,7 +8,7 @@
         OR
         <button class="agent-select-button btn btn-primary"
                 @click='lookupOptions'>
-            Find Identifier with GILDA
+            Find Identifier with Gilda
         </button>
         <span v-show='searching'>Searching...</span>
         <span v-show='options_empty'>No mesh IDs found...</span>

--- a/src/components/RelationSearch/RelationSearch.vue
+++ b/src/components/RelationSearch/RelationSearch.vue
@@ -2,9 +2,10 @@
   <div class='relation-search nvm'
        :style="`cursor: ${(searching) ? 'progress': 'auto'};`">
     <div id="search-row">
+      <small class="text-muted">On this page, you can search for statements by specifying one or more constraints such as agent, statement type, MeSH term, or paper. By default, a single agent search box is shown. You can add a second agent using the “+ Add agent” button, or remove it with the red “×” button. Additional constraint types (type, MeSH, paper) are always available below. After filling in your desired constraints, click the “Search” button to retrieve statements that match your criteria.</small>
       <div class="nav-btn">
         <h4>
-          Query Constraints (TESTING)
+          Statement Searching (Development)
           <button class="btn"
                   :disabled="cannotGoBack"
                   @click="backButton">
@@ -44,7 +45,7 @@
         <button
           class="btn btn-sm btn-outline-primary"
           @click="addAgent"
-          :disabled="hasAgentConstraints.length >= 2"
+          :disabled="hasAgentConstraints.length >= 3"
         >
           + Add agent
         </button>
@@ -57,7 +58,7 @@
         :key="pair.idx"
       >
         <template v-if="pair.c.class === 'HasType'">
-          <b>Type:</b>
+          <b>Statement Relation Types:</b>
           <type-select v-model="pair.c.constraint"></type-select>
           <br>
         </template>
@@ -148,7 +149,7 @@
       addConstraint(constraint_class) {
           let def = null;
           if (constraint_class === 'HasAgent') {
-            def = { role: 'any' };               // ← keep it minimal
+            def = { role: 'any' };
           } else if (constraint_class === 'HasType') {
             def = { stmt_types: [] };
           } else if (constraint_class === 'FromMeshIds') {

--- a/src/components/TypeSelect/TypeSelect.vue
+++ b/src/components/TypeSelect/TypeSelect.vue
@@ -1,59 +1,92 @@
 <template>
-  <span class="type-select">
-    <select class="form-control" v-model="selected_type">
-      <option :value="null" selected disabled hidden>Select type...</option>
-      <option v-for="type_name in type_options"
-              :value="type_name"
-              :key="type_name">
-        {{ type_name }}
-      </option>
-    </select>
-    <span class="form-check">
-      <input type="checkbox" class="form-check-input" id="inc_subtypes"
-             v-model="include_subclasses">
-      <label class="form-check-label" for="inc_subtypes">Include subtypes</label>
-    </span>
-  </span>
+<span class="type-select">
+  <multiselect
+    v-model="selected_types"
+    :options="typeOptions"
+    :multiple="true"
+    :close-on-select="true"
+    :clear-on-select="false"
+    :preserve-search="true"
+    :searchable="selected_types.length === 0"
+    placeholder="Select type(s)..."
+    :show-labels="true"
+    select-label=""
+    deselect-label="remove"
+  />
+  <div class="form-check form-check-inline">
+    <input
+      type="checkbox"
+      class="form-check-input"
+      id="inc_subtypes"
+      v-model="include_subclasses"
+    />
+    <label class="form-check-label" for="inc_subtypes">Include subtypes</label>
+  </div>
+</span>
 </template>
 
 <script>
-  export default {
-    name: "TypeSelect",
-    props: ['value'],
-    data: function() {
+import Multiselect from 'vue-multiselect'
+import 'vue-multiselect/dist/vue-multiselect.min.css'
+
+export default {
+  name: 'TypeSelect',
+  components: { Multiselect },
+  props: ['value'], // { stmt_types: string[], include_subclasses: boolean } | null
+  data () {
+    return {
+      selected_types: [],
+      include_subclasses: false,
+      isSyncingFromParent: false
+    }
+  },
+  computed: {
+    typeOptions () {
+      const t = this.$stmt_types
+      if (Array.isArray(t)) return t
+      if (t && typeof t === 'object') return Object.keys(t)
+      return []
+    },
+    constraint () {
+      if (!this.selected_types.length) return null
       return {
-        type_options: this.$stmt_types,
-        include_subclasses: null,
-        selected_type: null,
-      }
-    },
-    computed: {
-      constraint: function() {
-        if (!this.selected_type)
-          return null;
-        return {
-          stmt_types: [this.selected_type],
-          include_subclasses: this.include_subclasses
-        }
-      }
-    },
-    watch: {
-      constraint: function(constraint) {
-        this.$emit('input', constraint);
+        stmt_types: this.selected_types,
+        include_subclasses: this.include_subclasses
       }
     }
+  },
+  watch: {
+    selected_types () { this.emitIfUserChange() },
+    include_subclasses () { this.emitIfUserChange() },
+    value: {
+      handler (v) {
+        this.isSyncingFromParent = true
+        this.selected_types = v && Array.isArray(v.stmt_types) ? v.stmt_types.slice() : []
+        this.include_subclasses = !!(v && v.include_subclasses)
+        this.$nextTick(() => { this.isSyncingFromParent = false })
+      },
+      immediate: true
+    }
+  },
+  methods: {
+    emitIfUserChange () {
+      if (this.isSyncingFromParent) return
+      this.$emit('input', this.constraint)
+    }
   }
+}
 </script>
 
 <style scoped>
-  .type-select {
-    margin: 0.2em;
-  }
-  select, input, button {
-    margin: 0.2em;
-  }
-  .label {
-    margin-left: 0.5em;
-    margin-right: 0.2em;
-  }
+.type-select {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0.2em;
+  min-width: 400px;
+}
+.form-check-inline {
+  margin-left: 8px;
+  white-space: nowrap;
+}
 </style>

--- a/src/components/TypeSelect/TypeSelect.vue
+++ b/src/components/TypeSelect/TypeSelect.vue
@@ -79,7 +79,7 @@ export default {
 
 <style scoped>
 .type-select {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   gap: 12px;
   margin: 0.2em;


### PR DESCRIPTION
This PR reorganizes the layout and the functionality of db.indra.bio

- Show agent and type automatically on the front page, and make mesh and paper constraints hidden options that users can add as needed.
- Made the agent input box automatically detect namespace (hgnc, text, fplx)
- Allow multi-selection for relationship types so that users do not need to add or delete a separate constraint
- Allow 'add agent' button to add up to 3 agents for searching with a flexible removal button
- Add logic for clickable example texts to fill the search input automatically
- Made a second right bar to show more instructions and information
